### PR TITLE
Added `vuepress-plugin-github-linkify` plugin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,7 @@ import dotenv from 'dotenv'
 import { defaultTheme, viteBundler } from 'vuepress'
 import { docsearchPlugin } from '@vuepress/plugin-docsearch'
 import { containerPlugin } from '@vuepress/plugin-container'
+import { githubLinkifyPlugin } from 'vuepress-plugin-github-linkify'
 
 dotenv.config()
 
@@ -136,6 +137,10 @@ module.exports = {
 
         containerPlugin({
             type: 'tip'
+        }),
+
+        githubLinkifyPlugin({
+            repo: 'Laravel-Lang/common'
         })
     ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "@vuepress/plugin-container": "2.0.0-beta.60",
         "@vuepress/plugin-docsearch": "2.0.0-beta.60",
         "dotenv": "^15.0.0",
-        "vuepress": "2.0.0-beta.60"
+        "vuepress": "2.0.0-beta.60",
+        "vuepress-plugin-github-linkify": "^1.0.0"
     },
     "engines": {
         "node": ">=18.14"


### PR DESCRIPTION
Now links in the documentation will be displayed in a human way :)

![image](https://user-images.githubusercontent.com/10347617/221427393-437db998-3df4-4e1a-b1d4-570b85b7f2c9.png)
